### PR TITLE
Display icon and date in CurrentForecastFragment

### DIFF
--- a/app/src/main/java/com/goobar/io/ad340/api/CurrentWeather.kt
+++ b/app/src/main/java/com/goobar/io/ad340/api/CurrentWeather.kt
@@ -9,7 +9,9 @@ data class Coordinates(val lat: Float, val lon: Float)
  * Api response for OpenWeatherMap's /weather endpoint
  */
 data class CurrentWeather(
+    @field:Json(name = "dt") val date: Long,
     val name: String,
     val coord: Coordinates,
-    @field:Json(name = "main") val forecast: Forecast
+    @field:Json(name = "main") val forecast: Forecast,
+    val weather: List<WeatherDescription>
 )

--- a/app/src/main/java/com/goobar/io/ad340/api/WeatherDescription.kt
+++ b/app/src/main/java/com/goobar/io/ad340/api/WeatherDescription.kt
@@ -1,0 +1,3 @@
+package com.goobar.io.ad340.api
+
+data class WeatherDescription(val main: String, val description: String, val icon: String)

--- a/app/src/main/java/com/goobar/io/ad340/api/WeeklyForecast.kt
+++ b/app/src/main/java/com/goobar/io/ad340/api/WeeklyForecast.kt
@@ -2,7 +2,6 @@ package com.goobar.io.ad340.api
 
 import com.squareup.moshi.Json
 
-data class WeatherDescription(val main: String, val description: String, val icon: String)
 data class Temp(val min: Float, val max: Float)
 
 data class DailyForecast(

--- a/app/src/main/java/com/goobar/io/ad340/forecast/CurrentForecastFragment.kt
+++ b/app/src/main/java/com/goobar/io/ad340/forecast/CurrentForecastFragment.kt
@@ -5,12 +5,18 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import android.widget.TextView
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
+import coil.api.load
 import com.goobar.io.ad340.*
 import com.goobar.io.ad340.api.CurrentWeather
 import com.google.android.material.floatingactionbutton.FloatingActionButton
+import java.text.SimpleDateFormat
+import java.util.*
+
+private val DATE_FORMAT = SimpleDateFormat("MM-dd-yyyy")
 
 /**
  * Displays the current forecast for the current saved location
@@ -29,13 +35,19 @@ class CurrentForecastFragment : Fragment() {
         val view = inflater.inflate(R.layout.fragment_current_forecast, container, false)
         val locationName = view.findViewById<TextView>(R.id.locationName)
         val tempText = view.findViewById<TextView>(R.id.tempText)
+        val dateText = view.findViewById<TextView>(R.id.dateText)
+        val forecastIcon = view.findViewById<ImageView>(R.id.forecastIcon)
 
         tempDisplaySettingManager = TempDisplaySettingManager(requireContext())
 
         // Create the observer which updates the UI in response to forecast updates
-        val currentWeatherObserver = Observer<CurrentWeather> { weather ->
-            locationName.text = weather.name
-            tempText.text = formatTempForDisplay(weather.forecast.temp, tempDisplaySettingManager.getTempDisplaySetting())
+        val currentWeatherObserver = Observer<CurrentWeather> { currentWeather ->
+            locationName.text = currentWeather.name
+            tempText.text = formatTempForDisplay(currentWeather.forecast.temp, tempDisplaySettingManager.getTempDisplaySetting())
+            dateText.text = DATE_FORMAT.format(Date(currentWeather.date * 1000))
+
+            val iconId = currentWeather.weather[0].icon
+            forecastIcon.load("http://openweathermap.org/img/wn/${iconId}@2x.png")
         }
         forecastRepository.currentWeather.observe(viewLifecycleOwner, currentWeatherObserver)
 

--- a/app/src/main/res/layout/fragment_current_forecast.xml
+++ b/app/src/main/res/layout/fragment_current_forecast.xml
@@ -12,12 +12,12 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
         android:textAppearance="@style/TextAppearance.AppCompat.Display2"
+        app:layout_constraintBottom_toTopOf="@+id/dateText"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/forecastIcon"
+        app:layout_constraintTop_toTopOf="@+id/forecastIcon"
         tools:text="Seattle" />
 
     <TextView
@@ -42,5 +42,23 @@
         android:src="@drawable/ic_location_on_black_24dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
+
+    <ImageView
+        android:id="@+id/forecastIcon"
+        android:layout_width="80dp"
+        android:layout_height="80dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:src="@drawable/ic_wb_cloudy_black_24dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/dateText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="@+id/forecastIcon"
+        app:layout_constraintTop_toBottomOf="@+id/forecastIcon"
+        tools:text="Jun 4, 2020" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
* Adds a `date` property to `CurrentWeather` to pull that data from the api response
* Adds a list of `WeatherDescription` to `CurrentWeather` to pull the weather description informatino from the api response.  This mirrors the approach used in the `WeeklyForecast` model
* Moves `WeatherDescription` into its own file since it's reused for both `CurrentWeather` and `WeeklyForecast`
* Binds the updated `CurrentWeather` model into `CurrentForecastFragment` using the same formatting patterns as in `ForecastDetailsFragment`